### PR TITLE
Update graphite_utils.py

### DIFF
--- a/tendrl/monitoring_integration/graphite/graphite_utils.py
+++ b/tendrl/monitoring_integration/graphite/graphite_utils.py
@@ -70,6 +70,5 @@ def create_metrics(objects, cluster_details):
         except (AttributeError,KeyError) as ex:
             logger.log("error", NS.get("publisher_id", None),
                      {'message': str(ex)})
-            raise ex
     return metrics
 


### PR DESCRIPTION
Removing failure case: if creation of  metric for a  tendrl object fails then no metric is uploaded