### PR TITLE
Lock down the grafana required version to 4.5.2

### DIFF
--- a/tendrl-monitoring-integration.spec
+++ b/tendrl-monitoring-integration.spec
@@ -9,7 +9,7 @@ License: LGPLv2+
 URL: https://github.com/Tendrl/monitoring-integration
 
 Requires: tendrl-commons
-Requires: grafana
+Requires: grafana >= 4.5.2, grafana < 4.5.3
 Requires: graphite-web
 Requires: python-carbon
 Requires: python-whisper


### PR DESCRIPTION
The latest version available in grafana repo does not works
as expected with tendrl. This patch will lock down the
grafana version to 4.5.2

tendrl-bugid: Tendrl/monitoring-integration#224
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>