### PR TITLE
Corrected the initialization of cluster specific georep counts

### DIFF
--- a/tendrl/monitoring_integration/graphite/__init__.py
+++ b/tendrl/monitoring_integration/graphite/__init__.py
@@ -363,17 +363,17 @@ class GraphitePlugin():
             raise ex
 
     def set_geo_rep_session(self, cluster_data):
-        total = 0
-        partial = 0
-        up = 0
-        down = 0
-        created = 0
-        stopped = 0
-        paused = 0
-        geo_rep_mapper = {"total": total, "partial": partial, "up": up,
-                          "down": down, "created": created, "stopped": stopped,
-                          "paused": paused}
         for cluster in cluster_data:
+            # Initialize the counts map
+            geo_rep_mapper = {
+                "total": 0,
+                "partial": 0,
+                "up": 0,
+                "down": 0,
+                "created": 0,
+                "stopped": 0,
+                "paused": 0
+            }
             for volume in cluster.details["Volume"]:
                 try:
                     for key, value in volume["geo_rep_session"].items():


### PR DESCRIPTION
Earlier the counters were getting initialized only once and not at
cluster level. So effectively next set of cluster would accumulate
the previous cluster's count values as well. This skrews up the georep
session counts in grafana dashboard if multiple clusters are imported.

tendrl-bug-id: Tendrl/monitoring-integration#257
Signed-off-by: Shubhendu <shtripat@redhat.com>