### PR TITLE
Disable logging of successful connections

### DIFF
--- a/etc/tendrl/monitoring-integration/graphite/carbon.conf.sample
+++ b/etc/tendrl/monitoring-integration/graphite/carbon.conf.sample
@@ -105,7 +105,7 @@ PICKLE_RECEIVER_PORT = 2004
 # PICKLE_RECEIVER_BACKLOG = 1024
 
 # Set to false to disable logging of successful connections
-LOG_LISTENER_CONNECTIONS = True
+LOG_LISTENER_CONNECTIONS = False
 
 # Per security concerns outlined in Bug #817247 the pickle receiver
 # will use a more secure and slightly less efficient unpickler.


### PR DESCRIPTION
This info is something of debug leval and its flooding
the listener.log file. So setting the attribute
LOG_LISTENER_CONNECTIONS to false in carbon conf file

tendrl-bug-id: Tendrl/monitoring-integration#262
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>