### PR TITLE
Removed unwanted error message logged while no georep details for vol

### DIFF
--- a/tendrl/monitoring_integration/graphite/__init__.py
+++ b/tendrl/monitoring_integration/graphite/__init__.py
@@ -278,15 +278,6 @@ class GraphitePlugin():
                             except (etcd.EtcdKeyNotFound,
                                     AttributeError,
                                     KeyError) as ex:
-                                logger.log(
-                                    "error",
-                                    NS.get("publisher_id", None),
-                                    {
-                                        'message': "Error in retreiving "
-                                        "geo_replication data for "
-                                        "volume" + str(volume) + str(ex)
-                                    }
-                                )
                                 resource_detail[key] = {"total": 0,
                                                         "up": 0,
                                                         "down": 0,


### PR DESCRIPTION
If there are not georep session setup for a volume, the error message
gets looged again and again each sync time. Removed the same as its
un-wanted noise in the log files.

Signed-off-by: Shubhendu <shtripat@redhat.com>