### PR TITLE
grafana_host and grafana_port is missing in monitoring_integration.conf

### DIFF
--- a/etc/tendrl/monitoring-integration/monitoring-integration.conf.yaml.sample
+++ b/etc/tendrl/monitoring-integration/monitoring-integration.conf.yaml.sample
@@ -19,6 +19,12 @@ with_internal_profiling: False
 tags:
     - tendrl/integration/monitoring
 
+# Grafana host
+grafana_host: 127.0.0.1
+
+# Grafana port
+grafana_port: 3000 
+
 # List of dashboards to be uploaded
 dashboards:
     - tendrl-gluster-at-a-glance


### PR DESCRIPTION

tendrl-bug-id: Tendrl/monitoring-integration#339

Signed-off-by: GowthamShanmugaSundaram <gshanmug@redhat.com>