### PR TITLE
Using integration_id in alert message when cluster_short_name is None

### DIFF
--- a/tendrl/monitoring_integration/alert/utils.py
+++ b/tendrl/monitoring_integration/alert/utils.py
@@ -221,7 +221,10 @@ def find_cluster_short_name(integration_id):
         cluster = NS.tendrl.objects.Cluster(
             integration_id=integration_id
         ).load()
-        return cluster.short_name
+        if cluster.short_name in [None, '']:
+            return cluster.integration_id
+        else:
+            return cluster.short_name
     except EtcdKeyNotFound as ex:
         logger.log(
             "debug",


### PR DESCRIPTION
tendrl-bug-id: Tendrl/monitoring-integration#403

Signed-off-by: Gowthamshanmugasundaram <gshanmug@redhat.com>