### PR TITLE
Description of Capacity Available panel on Brick dashboards refers to a volume by mistake

### DIFF
--- a/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-bricks.json
+++ b/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-bricks.json
@@ -257,7 +257,7 @@
                 ],
                 "datasource": "",
                 "decimals": 1,
-                "description": "The Capacity Available panel displays the available capacity for a given volume.",
+                "description": "The Capacity Available panel displays the available capacity for a given brick.",
                 "format": "bytes",
                 "gauge": {
                     "maxValue": 100,


### PR DESCRIPTION

tendrl-bug-id: Tendrl/monitoring-integration#543
bugzilla: 1613527

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>