### PR TITLE
"Bricks" and "Brick Status" panels on Host and Volume dashboards doesn't use the same definition of brick state 

### DIFF
--- a/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-at-a-glance.json
+++ b/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-at-a-glance.json
@@ -674,15 +674,15 @@
                     "valueHandler": "Text Only"
                 }, {
                     "aggregation": "Last",
-                    "alias": "Up",
+                    "alias": "Started",
                     "displayType": "Regular",
                     "refId": "B",
-                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.brick_count.up), \"max\")),\"Up\")",
+                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.brick_count.up), \"max\")),\"Started\")",
                     "textEditor": true,
                     "valueHandler": "Text Only"
                 }, {
                     "aggregation": "Last",
-                    "alias": "Down",
+                    "alias": "Stopped",
                     "crit": 1,
                     "decimals": 0,
                     "display": true,
@@ -690,7 +690,7 @@
                     "displayType": "Regular",
                     "displayValueWithAlias": "When Alias Displayed",
                     "refId": "C",
-                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.brick_count.down), \"max\")),\"Down\")",
+                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.brick_count.down), \"max\")),\"Stopped\")",
                     "textEditor": true,
                     "units": "short",
                     "valueHandler": "Number Threshold",

--- a/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-hosts.json
+++ b/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-hosts.json
@@ -134,15 +134,15 @@
                     "valueHandler": "Text Only"
                 }, {
                     "aggregation": "Last",
-                    "alias": "Up",
+                    "alias": "Started",
                     "displayType": "Regular",
                     "refId": "B",
-                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.nodes.$host_name.brick_count.up), \"max\")),\"Up\")",
+                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.nodes.$host_name.brick_count.up), \"max\")),\"Started\")",
                     "textEditor": true,
                     "valueHandler": "Text Only"
                 }, {
                     "aggregation": "Last",
-                    "alias": "Down",
+                    "alias": "Stopped",
                     "crit": 1,
                     "decimals": 0,
                     "display": true,
@@ -150,7 +150,7 @@
                     "displayType": "Regular",
                     "displayValueWithAlias": "When Alias Displayed",
                     "refId": "C",
-                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.nodes.$host_name.brick_count.down), \"max\")),\"Down\")",
+                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.nodes.$host_name.brick_count.down), \"max\")),\"Stopped\")",
                     "textEditor": true,
                     "units": "none",
                     "valueHandler": "Number Threshold",

--- a/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-volumes.json
+++ b/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-volumes.json
@@ -151,17 +151,17 @@
                     "valueHandler": "Text Only"
                 }, {
                     "aggregation": "Last",
-                    "alias": "Up",
+                    "alias": "Started",
                     "decimals": 0,
                     "displayType": "Regular",
                     "refId": "B",
-                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.volumes.$volume_name.brick_count.up), \"max\")),\"Up\")",
+                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.volumes.$volume_name.brick_count.up), \"max\")),\"Started\")",
                     "textEditor": true,
                     "units": "none",
                     "valueHandler": "Text Only"
                 }, {
                     "aggregation": "Last",
-                    "alias": "Down",
+                    "alias": "Stopped",
                     "crit": 1,
                     "decimals": 0,
                     "display": true,
@@ -169,7 +169,7 @@
                     "displayType": "Regular",
                     "displayValueWithAlias": "When Alias Displayed",
                     "refId": "C",
-                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.volumes.$volume_name.brick_count.down), \"max\")),\"Down\")",
+                    "target": "alias(keepLastValue(consolidateBy(maxSeries(tendrl.names.$cluster_id.volumes.$volume_name.brick_count.down), \"max\")),\"Stopped\")",
                     "textEditor": true,
                     "units": "short",
                     "valueHandler": "Number Threshold",


### PR DESCRIPTION

tendrl-bug-id: Tendrl/monitoring-integration#545
bugzilla: 1614000

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>