### PR TITLE
Removed inactive link from healing panel of Brick dashboard

### DIFF
--- a/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-bricks.json
+++ b/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-bricks.json
@@ -529,7 +529,7 @@
                 },
                 "cornerRadius": 0,
                 "datasource": "",
-                "description": "The Healing panel displays healing information for a given brick based on healinfo.  See https://gluster.readthedocs.io/en/latest/Troubleshooting/heal-info-and-split-brain-resolution/  \nfor how to troubleshoot healing and split brain issues",
+                "description": "The Healing panel displays healing information for a given brick based on Healinfo, i.e. statistics of entries pending heal and split-brain.",
                 "displayName": "Healing",
                 "flipCard": false,
                 "flipTime": 5,


### PR DESCRIPTION
tendrl-bug-id: Tendrl/monitoring-integration#555
bugzilla: 1613529
Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

![screenshot from 2018-09-12 14-47-16](https://user-images.githubusercontent.com/8753636/45415232-cf10be80-b69a-11e8-98b7-cca49ba59d71.png)


