### PR TITLE
Updated description for Disk IOPS on host dashboard

### DIFF
--- a/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-hosts.json
+++ b/etc/tendrl/monitoring-integration/grafana/dashboards/tendrl-gluster-hosts.json
@@ -1326,7 +1326,7 @@
                 "dashLength": 10,
                 "dashes": false,
                 "datasource": "",
-                "description": "The Disk Throughput panel shows the host’s aggregated read and writes from/to disks over a period of time.",
+                "description": "The Disk Throughput panel shows the host’s aggregated read and writes from/to disks for all the block devices of the machine over a period of time.",
                 "fill": 1,
                 "id": 23,
                 "legend": {
@@ -1397,7 +1397,7 @@
                 "dashLength": 10,
                 "dashes": false,
                 "datasource": "",
-                "description": "The Disk IOPS panel shows the host’s aggregated read and writes disk IOPS over a period of time.",
+                "description": "The Disk IOPS panel shows the host’s aggregated read and writes disk IOPS for all the block devices of the machine over a period of time.",
                 "fill": 1,
                 "id": 24,
                 "legend": {
@@ -1465,7 +1465,7 @@
                 "dashLength": 10,
                 "dashes": false,
                 "datasource": "",
-                "description": "The Disk IO Latency panel shows the host’s aggregated I/O time over a period of time.",
+                "description": "The Disk IO Latency panel shows the host’s aggregated I/O time for all the block devices of the machine over a period of time.",
                 "fill": 1,
                 "id": 25,
                 "legend": {


### PR DESCRIPTION
tendrl-bug-id: Tendrl/monitoring-integration#556
bugzilla: 1614012
Signed-off-by: Anmol Sachan <anmol13694@gmail.com>


![screenshot from 2018-09-11 19-14-31](https://user-images.githubusercontent.com/8753636/45364128-f746e180-b5f6-11e8-80ef-5c7b2e07f986.png)
![screenshot from 2018-09-11 19-14-17](https://user-images.githubusercontent.com/8753636/45364129-f7df7800-b5f6-11e8-8921-7354d592c567.png)
![screenshot from 2018-09-11 19-14-07](https://user-images.githubusercontent.com/8753636/45364130-f7df7800-b5f6-11e8-93b3-32eedd677290.png)
